### PR TITLE
Allow multiple hosts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "couchbasestreamswrapper"
 
 organization := "io.dronekit"
 
-version := "2.6.0"
+version := "2.7.0"
 
 scalaVersion := "2.12.6"
 

--- a/src/main/scala/io/dronekit/CouchbaseStreamsWrapper.scala
+++ b/src/main/scala/io/dronekit/CouchbaseStreamsWrapper.scala
@@ -103,6 +103,7 @@ object CouchbaseStreamsWrapper {
 
   val temporaryFailureRetryMs = 50
   val temporaryFailureMaxRetries = 5
+
 }
 
 trait JsonSerializer[T] {
@@ -136,11 +137,17 @@ object JsonSerializer extends JsonSerializerLowPriority {
   * @param ec Execution Context for Futures and Streams
   * @param mat Materializer for Akka-Streams
   */
-class CouchbaseStreamsWrapper(host: String, bucketName: String, password: String)
+
+class CouchbaseStreamsWrapper(hosts: List[String], bucketName: String, password: String)
                     (implicit ec: ExecutionContext, mat: ActorMaterializer)
 {
+
+  def this(host: String, bucketName: String, password: String)(implicit ec: ExecutionContext, mat: ActorMaterializer) {
+    this(List(host), bucketName, password)
+  }
+
   // Reuse the env here
-  val cluster = CouchbaseCluster.create(CouchbaseStreamsWrapper.env, host)
+  val cluster = CouchbaseCluster.create(CouchbaseStreamsWrapper.env, hosts.asJava)
   val bucket = cluster.openBucket(bucketName, password)
   val log: Logger = Logger(LoggerFactory.getLogger(getClass))
 

--- a/src/main/scala/io/dronekit/CouchbaseStreamsWrapper.scala
+++ b/src/main/scala/io/dronekit/CouchbaseStreamsWrapper.scala
@@ -138,17 +138,19 @@ object JsonSerializer extends JsonSerializerLowPriority {
   * @param mat Materializer for Akka-Streams
   */
 
-class CouchbaseStreamsWrapper(hosts: List[String], bucketName: String, password: String)
+class CouchbaseStreamsWrapper(hosts: List[String], bucketName: String, userName: String, password: String)
                     (implicit ec: ExecutionContext, mat: ActorMaterializer)
 {
 
+  // legacy Couchbase setup method - assumes the bucket name and user name are identical
   def this(host: String, bucketName: String, password: String)(implicit ec: ExecutionContext, mat: ActorMaterializer) {
-    this(List(host), bucketName, password)
+    this(List(host), bucketName, bucketName, password)
   }
 
   // Reuse the env here
   val cluster = CouchbaseCluster.create(CouchbaseStreamsWrapper.env, hosts.asJava)
-  val bucket = cluster.openBucket(bucketName, password)
+  cluster.authenticate(userName, password)
+  val bucket = cluster.openBucket(bucketName)
   val log: Logger = Logger(LoggerFactory.getLogger(getClass))
 
   /**


### PR DESCRIPTION
Overload the constructor to allow passing either a single host or
multiple hosts, which we will need for implementing robust service
discovery for couchbase cluster nodes