### PR TITLE
Log id of couchbase documents that failed to deserialize

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "couchbasestreamswrapper"
 
 organization := "io.dronekit"
 
-version := "2.7.1"
+version := "2.7.4"
 
 scalaVersion := "2.12.6"
 


### PR DESCRIPTION
Create a new execption type that will contain the ID of an object that
fails to deserialize from couchbase, so those IDs show up in the logs
and make debugging easier.